### PR TITLE
Add dynamic header and interactive about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
     <header class="bg-dark text-white text-center py-5">
         <h1>Ayushi's Portfolio</h1>
-        <p>Data Scientist | Machine Learning | AI</p>
+        <p><span id="typed"></span></p>
     </header>
 
     <section class="container my-5">
@@ -21,6 +21,10 @@
             <div class="col-md-8">
                 <h2>About Me</h2>
                 <p>Hi, I'm Ayushi! I specialize in data science, machine learning, and AI.</p>
+                <div id="moreText" class="about-more">
+                    <p>I enjoy turning data into actionable insights and building machine learning models. When I'm not coding, I love exploring new technologies and contributing to open-source projects.</p>
+                </div>
+                <button id="readMoreBtn" class="btn btn-primary btn-sm mt-2" type="button" aria-expanded="false">Read More</button>
             </div>
         </div>
     </section>
@@ -54,6 +58,31 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/typed.js@2.1.0/dist/typed.umd.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            new Typed('#typed', {
+                strings: ['Data Scientist', 'Machine Learning Enthusiast', 'AI Researcher'],
+                typeSpeed: 50,
+                backSpeed: 25,
+                loop: true
+            });
+
+            var btn = document.getElementById('readMoreBtn');
+            var more = document.getElementById('moreText');
+            btn.addEventListener('click', function () {
+                if (more.style.display === 'none' || more.style.display === '') {
+                    more.style.display = 'block';
+                    btn.textContent = 'Read Less';
+                    btn.setAttribute('aria-expanded', 'true');
+                } else {
+                    more.style.display = 'none';
+                    btn.textContent = 'Read More';
+                    btn.setAttribute('aria-expanded', 'false');
+                }
+            });
+        });
+    </script>
 </body>
 </html>
 

--- a/style.css
+++ b/style.css
@@ -18,3 +18,13 @@ h1, h2 {
 .card:hover {
     transform: scale(1.05);
 }
+
+/* Dynamic header typing effect */
+#typed {
+    font-weight: 600;
+}
+
+/* Collapsible about section */
+.about-more {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- animate the header tagline with Typed.js
- add expandable "About Me" section with toggle button
- style interactive elements

## Testing
- `npx prettier --check index.html style.css` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbf435c4832ab9ed87a2f61a354f